### PR TITLE
Revert the original version of README

### DIFF
--- a/README
+++ b/README
@@ -175,14 +175,4 @@ src/unit_test_stubs Unit test stubs that replicate CTSM code simpler
          ./case.submit               # submit script
                                      # (NOTE: ./xmlchange RESUBMIT=10 to set RESUBMIT to number
                                      # #  of times to automatically resubmit -- 10 in this example)
-==========================================
-This is used for testing the git workflow
-==========================================
-The first commit made on github and it is 
-meant to test whether adding a commit on 
-github will notify the user by email
-==========================================
-It turns out whether a commit or a comment
-made on github by myself will not trigger
-the email notification
-==========================================
+


### PR DESCRIPTION
Revert back to the original version by deleting the additional 11 lines added at the end of README
